### PR TITLE
Disable all external access to the otel collector

### DIFF
--- a/support/ecs-otel-task-metrics-config.yaml
+++ b/support/ecs-otel-task-metrics-config.yaml
@@ -1,6 +1,6 @@
 extensions:
   health_check:
-    endpoint: 0.0.0.0:13133
+    endpoint: 127.0.0.1:13133
     check_collector_pipeline:
       enabled: true
       interval: 5m
@@ -12,13 +12,13 @@ receivers:
   otlp:
     protocols:
       grpc:
-        endpoint: 0.0.0.0:4317
+        endpoint: 127.0.0.1:4317
       http:
-        endpoint: 0.0.0.0:4318
+        endpoint: 127.0.0.1:4318
   awsxray:
     transport: udp
   statsd:
-    endpoint: 0.0.0.0:8125
+    endpoint: 127.0.0.1:8125
     aggregation_interval: 60s
   awsecscontainermetrics:
 


### PR DESCRIPTION
There is no need for the otel collector side-car to be accessed outside the ecs main container.

**Why this change?**
- Load balancers were sending traffic to the side car ports and thus the need to make sure only local access is enabled.