### PR TITLE
Fix overwatch support remote write api failures

### DIFF
--- a/cdk/lib/overwatch-support-stack.ts
+++ b/cdk/lib/overwatch-support-stack.ts
@@ -206,16 +206,12 @@ export class OverwatchSupportStack extends ExtendedStack {
       workspace: overwatchSupport.workspace,
     });
 
-    const prometheusEndpoint =
-      overwatchSupport.workspace.attrPrometheusEndpoint;
-    const prometheusEndpointRemoteWrite = prometheusEndpoint.endsWith('/')
-      ? prometheusEndpoint.slice(0, -1)
-      : prometheusEndpoint;
+    const prometheusRegion = Stack.of(this).region;
     new OtelSupportConstruct(this, 'OtelSupportConstruct', {
       parameterName: '/app/global/otel',
       parameterDescription: 'Global OpenTelemetry configuration',
-      region: Stack.of(this).region,
-      prometheusEndpoint: `${prometheusEndpointRemoteWrite}/api/v1/remote_write`,
+      region: prometheusRegion,
+      prometheusEndpoint: `https://aps-workspaces.${prometheusRegion}.amazonaws.com/workspaces/${overwatchSupport.workspace.attrWorkspaceId}/api/v1/remote_write`,
     });
   }
 

--- a/cdk/lib/overwatch-support-stack.ts
+++ b/cdk/lib/overwatch-support-stack.ts
@@ -206,11 +206,16 @@ export class OverwatchSupportStack extends ExtendedStack {
       workspace: overwatchSupport.workspace,
     });
 
+    const prometheusEndpoint =
+      overwatchSupport.workspace.attrPrometheusEndpoint;
+    const prometheusEndpointRemoteWrite = prometheusEndpoint.endsWith('/')
+      ? prometheusEndpoint.slice(0, -1)
+      : prometheusEndpoint;
     new OtelSupportConstruct(this, 'OtelSupportConstruct', {
       parameterName: '/app/global/otel',
       parameterDescription: 'Global OpenTelemetry configuration',
       region: Stack.of(this).region,
-      prometheusEndpoint: overwatchSupport.workspace.attrPrometheusEndpoint,
+      prometheusEndpoint: `${prometheusEndpointRemoteWrite}/api/v1/remote_write`,
     });
   }
 


### PR DESCRIPTION
Services consuming the collector were getting 404 error on side car start up due to the incomplete prometheus endpoint url.