### PR TITLE
Remove cloudwatch metrics publishing

### DIFF
--- a/support/ecs-otel-task-metrics-config.yaml
+++ b/support/ecs-otel-task-metrics-config.yaml
@@ -261,7 +261,7 @@ service:
     metrics/application:
       receivers: [otlp, statsd]
       processors: [resourcedetection,batch/metrics]
-      exporters: [prometheusremotewrite/application, awsemf/application]
+      exporters: [prometheusremotewrite/application]
     metrics/ecs:
       receivers: [awsecscontainermetrics]
       processors: [filter, metricstransform, resource]

--- a/support/lambda-otel-task-metrics-config.yaml
+++ b/support/lambda-otel-task-metrics-config.yaml
@@ -38,5 +38,5 @@ service:
 
     metrics/application:
       receivers: [otlp]
-      exporters: [prometheusremotewrite/application,awsemf/application]
+      exporters: [prometheusremotewrite/application]
   extensions: [sigv4auth]


### PR DESCRIPTION
Only send metrics to prometheus.